### PR TITLE
correct fsf address

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ generating code coverage data.
 
 ![alt text][AFL-status-screen]
 
-[AFL-status-screen]: /doc/AFL_status_screen.png "AFL Fuzzing Cycle"
+[AFL-status-screen]: doc/AFL_status_screen.png "AFL Fuzzing Cycle"
 
 Here is a sample of what the `afl-cov` output looks like:
 
@@ -191,7 +191,7 @@ opportunity to find bugs.
 
 ![alt text][AFL-lcov-web-report]
 
-[AFL-lcov-web-report]: /doc/AFL_lcov_web_report.png "AFL lcov web report"
+[AFL-lcov-web-report]: doc/AFL_lcov_web_report.png "AFL lcov web report"
 
 ### Other Examples
 The workflow above is probably the main strategy for using `afl-cov`. However,

--- a/afl-cov
+++ b/afl-cov
@@ -23,7 +23,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with this program; if not, write to the Free Software
-#  Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307
+#  Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02111-1301,
 #  USA
 #
 


### PR DESCRIPTION
Applied correct-old-fsf-address.patch from Debian packaging, very very minor, but however.

BTW, a Debian package of afl-cov is coming up: https://bugs.debian.org/796821

Best,
D. Stender
