### PR TITLE
added cover-corpus switch

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -120,92 +120,211 @@ def process_afl_test_cases(cargs):
             break
 
         dir_ctr = 0
-        for fuzz_dir in cov_paths['dirs']:
-
-            num_files = 0
+        if cargs.cover_corpus:
             new_files = []
-            tmp_files = import_test_cases(fuzz_dir + '/queue')
-            dir_ctr  += 1
 
-            for f in tmp_files:
-                if f not in afl_files:
-                    afl_files.append(f)
-                    new_files.append(f)
+            # build list of test files
+            for fuzz_dir in cov_paths['dirs']:
+                tmp_files = import_test_cases(fuzz_dir + '/queue')
+                for f in tmp_files:
+                    if f not in afl_files:
+                        afl_files.append(f)
+                        new_files.append(f)  # needed below to check if sleep is necessary
 
-            if new_files:
-                logr("\n*** Imported %d new test cases from: %s\n" \
-                        % (len(new_files), (fuzz_dir + '/queue')),
-                        cov_paths['log_file'], cargs)
+            # set up directories
+            if not cargs.afl_fuzzing_dir:
+                print "[*] Must specify AFL fuzzing dir with --afl-fuzzing-dir or -d"
+                return False
 
-            for f in new_files:
+            def_dir = cargs.afl_fuzzing_dir + '/cov'
 
-                out_lines = []
-                curr_cycle = get_cycle_num(num_files, cargs)
+            if not is_dir(def_dir + '/diff'):
+                os.mkdir(def_dir + '/diff')
+            if not is_dir(def_dir + '/lcov'):
+                os.mkdir(def_dir + '/lcov')
+            if not is_dir(def_dir + '/web'):
+                os.mkdir(def_dir + '/web')
 
-                logr("[+] AFL test case: %s (%d / %d), cycle: %d" \
-                        % (os.path.basename(f), num_files, len(afl_files),
-                        curr_cycle), cov_paths['log_file'], cargs)
+            # run initial command
+            lcov_opts = ''
+            if cargs.enable_branch_coverage:
+                lcov_opts += ' --rc lcov_branch_coverage=1'
 
-                gen_paths(fuzz_dir, cov_paths, f, cargs)
+            run_cmd(cargs.lcov_path +
+                    lcov_opts +
+                    " --no-checksum --capture --initial" +
+                    " --directory " + cargs.code_dir +
+                    " --output-file " +
+                    def_dir + '/lcov/tracefile.lcov_base',
+                    cov_paths, cargs, NO_OUTPUT)
 
-                if dir_ctr > 1 and curr_file \
-                        and not cov_paths['dirs'][fuzz_dir]['prev_file']:
-                    cov_paths['dirs'][fuzz_dir]['prev_file'] = curr_file
-                    cov_paths['dirs'][fuzz_dir]['prev_lcov_base'] = curr_lcov_base
-                    cov_paths['dirs'][fuzz_dir]['prev_lcov_info'] = curr_lcov_info
-                    cov_paths['dirs'][fuzz_dir]['prev_lcov_info_final'] = curr_lcov_info_final
+            # run all afl_files
+            for index, f in enumerate(afl_files):
+                curr_cycle = get_cycle_num(index, cargs)
+
+                logr("[+] AFL test case: %s (%d / %d), cycle: %d" % (os.path.basename(f), index + 1, len(afl_files),
+                                                                     curr_cycle), cov_paths['log_file'], cargs)
 
                 if cargs.coverage_cmd:
-
-                    ### execute the command to generate code coverage stats
-                    ### for the current AFL test case file
+                    # execute the command to generate code coverage stats
+                    # for the current AFL test case file
                     if run_once:
                         run_cmd(cargs.coverage_cmd.replace('AFL_FILE', f),
                                 cov_paths, cargs, NO_OUTPUT)
                     else:
-                        out_lines = run_cmd(cargs.coverage_cmd.replace('AFL_FILE', f),
+                        run_cmd(cargs.coverage_cmd.replace('AFL_FILE', f),
                                 cov_paths, cargs, WANT_OUTPUT)
                         run_once = True
+            # capture coverage
+            run_cmd(cargs.lcov_path +
+                    lcov_opts +
+                    " --no-checksum --capture --directory " +
+                    cargs.code_dir +
+                    " --output-file " +
+                    def_dir + '/lcov/tracefile.lcov_info',
+                    cov_paths, cargs, NO_OUTPUT)
 
-                    ### generate the code coverage stats for this test case
-                    gen_coverage(fuzz_dir, cov_paths, cargs)
+            # merge base and info (and exclude, if needed)
+            if cargs.disable_lcov_exclude_pattern:
+                out_lines = run_cmd(cargs.lcov_path +
+                                    lcov_opts +
+                                    " --no-checksum -a " + def_dir + '/lcov/tracefile.lcov_base' +
+                                    " -a " + def_dir + '/lcov/tracefile.lcov_info' +
+                                    " --output-file " + def_dir + '/lcov/tracefile.lcov_info_final',
+                                    cov_paths, cargs, WANT_OUTPUT)
+            else:
+                run_cmd(cargs.lcov_path +
+                        lcov_opts +
+                        " --no-checksum -a " + def_dir + '/lcov/tracefile.lcov_base' +
+                        " -a " + def_dir + '/lcov/tracefile.lcov_info' +
+                        " --output-file " + def_dir + '/lcov/tracefile.lcov_info_tmp',
+                        cov_paths, cargs, NO_OUTPUT)
 
-                    ### diff to the previous code coverage, look for new
-                    ### lines/functions, and write out results
-                    if cov_paths['dirs'][fuzz_dir]['prev_file']:
-                        coverage_diff(curr_cycle, fuzz_dir, cov_paths,
-                                f, cov, cargs)
+                out_lines = run_cmd(cargs.lcov_path +
+                                    lcov_opts +
+                                    " --no-checksum -r " + def_dir + '/lcov/tracefile.lcov_info_tmp' +
+                                    " " + cargs.lcov_exclude_pattern + "  --output-file " +
+                                    def_dir + '/lcov/tracefile.lcov_info_final',
+                                    cov_paths, cargs, WANT_OUTPUT)
 
-                    if not cargs.disable_lcov_web and cargs.lcov_web_all:
-                        gen_web_cov_report(fuzz_dir, cov_paths, cargs)
+            for line in out_lines:
+                m = re.search('^\s+(lines\.\..*\:\s.*)', line)
+                if m and m.group(1):
+                    logr("    " + m.group(1), cov_paths['log_file'], cargs)
+                else:
+                    m = re.search('^\s+(functions\.\..*\:\s.*)', line)
+                    if m and m.group(1):
+                        logr("    " + m.group(1), cov_paths['log_file'], cargs)
+                    else:
+                        if cargs.enable_branch_coverage:
+                            m = re.search('^\s+(branches\.\..*\:\s.*)', line)
+                            if m and m.group(1):
+                                logr("    " + m.group(1),
+                                     cov_paths['log_file'], cargs)
 
-                    ### log the output of the very first coverage command to
-                    ### assist in troubleshooting
-                    if len(out_lines):
-                        logr("\n\n++++++ BEGIN - first exec output for CMD: %s" % \
-                                (cargs.coverage_cmd.replace('AFL_FILE', f)),
-                                cov_paths['log_file'], cargs)
-                        for line in out_lines:
-                            logr("    %s" % (line), cov_paths['log_file'], cargs)
-                        logr("++++++ END\n", cov_paths['log_file'], cargs)
+            # generate report
+            web_link = def_dir + '/web/index.html'
+            genhtml_opts = ''
+            if cargs.enable_branch_coverage:
+                genhtml_opts += ' --branch-coverage'
 
-                if dir_ctr == 1:
-                    curr_file      = f
-                    curr_lcov_base = cov_paths['dirs'][fuzz_dir]['lcov_base']
-                    curr_lcov_info = cov_paths['dirs'][fuzz_dir]['lcov_info']
-                    curr_lcov_info_final = cov_paths['dirs'][fuzz_dir]['lcov_info_final']
+            run_cmd(cargs.genhtml_path +
+                    genhtml_opts +
+                    ' --output-directory ' +
+                    def_dir + '/web ' +
+                    def_dir + '/lcov/tracefile.lcov_info_final',
+                    cov_paths, cargs, NO_OUTPUT)
 
-                cov_paths['dirs'][fuzz_dir]['prev_file'] = f
+            logr("[+] Final lcov web report: %s" % web_link,
+                 cov_paths['log_file'], cargs)
 
-                num_files += 1
-                tot_files += 1
+        else:
+            for fuzz_dir in cov_paths['dirs']:
 
-                if cargs.afl_queue_id_limit \
-                        and num_files > cargs.afl_queue_id_limit:
-                    logr("[+] queue/ id limit of %d reached..." \
-                            % cargs.afl_queue_id_limit,
+                num_files = 0
+                new_files = []
+                tmp_files = import_test_cases(fuzz_dir + '/queue')
+                dir_ctr  += 1
+
+                for f in tmp_files:
+                    if f not in afl_files:
+                        afl_files.append(f)
+                        new_files.append(f)
+
+                if new_files:
+                    logr("\n*** Imported %d new test cases from: %s\n" \
+                            % (len(new_files), (fuzz_dir + '/queue')),
                             cov_paths['log_file'], cargs)
-                    break
+
+                for f in new_files:
+
+                    out_lines = []
+                    curr_cycle = get_cycle_num(num_files, cargs)
+
+                    logr("[+] AFL test case: %s (%d / %d), cycle: %d" \
+                            % (os.path.basename(f), num_files, len(afl_files),
+                            curr_cycle), cov_paths['log_file'], cargs)
+
+                    gen_paths(fuzz_dir, cov_paths, f, cargs)
+
+                    if dir_ctr > 1 and curr_file \
+                            and not cov_paths['dirs'][fuzz_dir]['prev_file']:
+                        cov_paths['dirs'][fuzz_dir]['prev_file'] = curr_file
+                        cov_paths['dirs'][fuzz_dir]['prev_lcov_base'] = curr_lcov_base
+                        cov_paths['dirs'][fuzz_dir]['prev_lcov_info'] = curr_lcov_info
+                        cov_paths['dirs'][fuzz_dir]['prev_lcov_info_final'] = curr_lcov_info_final
+
+                    if cargs.coverage_cmd:
+
+                        ### execute the command to generate code coverage stats
+                        ### for the current AFL test case file
+                        if run_once:
+                            run_cmd(cargs.coverage_cmd.replace('AFL_FILE', f),
+                                    cov_paths, cargs, NO_OUTPUT)
+                        else:
+                            out_lines = run_cmd(cargs.coverage_cmd.replace('AFL_FILE', f),
+                                    cov_paths, cargs, WANT_OUTPUT)
+                            run_once = True
+
+                        ### generate the code coverage stats for this test case
+                        gen_coverage(fuzz_dir, cov_paths, cargs)
+
+                        ### diff to the previous code coverage, look for new
+                        ### lines/functions, and write out results
+                        if cov_paths['dirs'][fuzz_dir]['prev_file']:
+                            coverage_diff(curr_cycle, fuzz_dir, cov_paths,
+                                    f, cov, cargs)
+
+                        if not cargs.disable_lcov_web and cargs.lcov_web_all:
+                            gen_web_cov_report(fuzz_dir, cov_paths, cargs)
+
+                        ### log the output of the very first coverage command to
+                        ### assist in troubleshooting
+                        if len(out_lines):
+                            logr("\n\n++++++ BEGIN - first exec output for CMD: %s" % \
+                                    (cargs.coverage_cmd.replace('AFL_FILE', f)),
+                                    cov_paths['log_file'], cargs)
+                            for line in out_lines:
+                                logr("    %s" % (line), cov_paths['log_file'], cargs)
+                            logr("++++++ END\n", cov_paths['log_file'], cargs)
+
+                    if dir_ctr == 1:
+                        curr_file      = f
+                        curr_lcov_base = cov_paths['dirs'][fuzz_dir]['lcov_base']
+                        curr_lcov_info = cov_paths['dirs'][fuzz_dir]['lcov_info']
+                        curr_lcov_info_final = cov_paths['dirs'][fuzz_dir]['lcov_info_final']
+
+                    cov_paths['dirs'][fuzz_dir]['prev_file'] = f
+
+                    num_files += 1
+                    tot_files += 1
+
+                    if cargs.afl_queue_id_limit \
+                            and num_files > cargs.afl_queue_id_limit:
+                        logr("[+] queue/ id limit of %d reached..." \
+                                % cargs.afl_queue_id_limit,
+                                cov_paths['log_file'], cargs)
+                        break
 
         if cargs.live:
             if is_afl_fuzz_running(cargs):
@@ -1039,6 +1158,10 @@ def parse_cmdline():
             default=False)
     p.add_argument("--live", action='store_true',
             help="Process a live AFL directory, and afl-cov will exit when it appears afl-fuzz has been stopped",
+            default=False)
+    p.add_argument("--cover-corpus", action='store_true',
+            help="Measure coverage after running all available tests instead of individually per queue file",
+            # TODO: Document that queue limit should/will be ignored!
             default=False)
     p.add_argument("--sleep", type=int,
             help="In --live mode, # of seconds to sleep between checking for new queue files",


### PR DESCRIPTION
See issue #21.

It is a relatively dirty hack in my opinion, but I thought it might be useful for others even in this state. To really make it work more sustainably, a lot of (semi) global state needs to be removed from various functions. I'm not too keen on refactoring the whole script, so I just tried to go with the bare minimum slapping everything in an if block and duplicating code instead.

When using --cover-corpus, afl-cov will run all queue files and then measure coverage. I did not implement a comparison with the last run, so subsequent runs will overwrite previous results. Also the queue limit will (of course) not be respected, it will always run all queue files.

I hope this helps others too, it is definitely nice to get a report of all test cases relatively fast. :)