### PR TITLE
add support for afl-clang-fast

### DIFF
--- a/afl-cov
+++ b/afl-cov
@@ -575,6 +575,8 @@ def lcov_gen_coverage(cov_paths, cargs):
         lcov_opts += ' --rc lcov_branch_coverage=1'
     if cargs.follow:
         lcov_opts += ' --follow'
+    if cargs.clang:
+        lcov_opts += ' --gcov-tool afl-cov-wrapper '
 
     run_cmd(cargs.lcov_path \
             + lcov_opts
@@ -800,6 +802,8 @@ def init_tracking(cov_paths, cargs):
         lcov_opts = ''
         if cargs.enable_branch_coverage:
             lcov_opts += ' --rc lcov_branch_coverage=1 '
+        if cargs.clang:
+            lcov_opts += ' --gcov-tool afl-cov-wrapper '
 
         ### reset code coverage counters - this is done only once as
         ### afl-cov is spinning up even if AFL is running in parallel mode
@@ -1204,6 +1208,8 @@ def parse_cmdline():
             help="Print version and exit", default=False)
     p.add_argument("-q", "--quiet", action='store_true',
             help="Quiet mode", default=False)
+    p.add_argument("--clang", action='store_true',
+            help="Support clang-based (afl-clang-fast) instrumentation", default=False)
 
     return p.parse_args()
 

--- a/afl-cov-wrapper
+++ b/afl-cov-wrapper
@@ -1,0 +1,2 @@
+#!/bin/bash
+exec ${AFL_COV_LLVM:-llvm-cov} gcov "$@"


### PR DESCRIPTION
By default, the wrapper script will execute `llvm-cov`, which can be overriden by the environment variable AFL_COV_LLVM. As an example:

```
AFL_COV_LLVM=llvm-cov-8 afl-cov -d <outdir> -c <srcdir> -e "<binpath> < AFL_FILE" --clang --enable-branch-coverage
```